### PR TITLE
Fix docker build, move to python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ htmlcov
 .coverage
 *.swo
 .tox
+build/
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-stretch
+FROM python:3.7.17-buster
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35
+envlist = py27, py37
 
 [testenv]
 commands=python setup.py test


### PR DESCRIPTION
Docker build stopped working sometime between now and the last time we build for the python 3 compatibility.  Went ahead and upgraded to 3.7 as 3.5 is no longer supported either.